### PR TITLE
Update dependency to not show deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-pagination": "^0.6.6",
+    "ember-cli-pagination": "^0.9.0",
     "emberx-select": "^2.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
We need to update this dependency to use the newest version of ember-cli-pagination and not use the old store.find and use store.query instead