### PR TITLE
Fixes to the route mixin in order to work well with additional params…

### DIFF
--- a/app/mixins/table-pager/column.js
+++ b/app/mixins/table-pager/column.js
@@ -21,6 +21,9 @@ export default Ember.Object.extend({
     //order in which to display the fields
     order: 0,
 
+    // show the quick filter or not
+    showingFilter: false,
+
     // value on the filter for this column
     filterValue: null,
 

--- a/app/mixins/table-pager/controller.js
+++ b/app/mixins/table-pager/controller.js
@@ -90,7 +90,7 @@ export default Ember.Mixin.create({
 
     actions: {
       toggleFilter: function(column) {
-        Ember.$('#filter-' + column.fieldName).toggleClass('hidden');
+        column.set('showingFilter', !column.get('showingFilter'));
       }
     }
 });

--- a/app/templates/table-pager/table/table-header.hbs
+++ b/app/templates/table-pager/table/table-header.hbs
@@ -9,7 +9,7 @@
           <a {{action 'sortField' item.fieldName}}>
             <i class="fa fa-sort"></i>
           </a>
-          <div class="row hidden" id="filter-{{item.fieldName}}">
+          <div class="row {{if item.showingFilter '' 'hidden'}}">
             <div class="col-md-12">
               {{input type="text" class="form-control" value=item.filterValue name=item.fieldName }}
             </div>


### PR DESCRIPTION
… (like a sub-list)

With this change, we'll have to implement the custom model like this (from subject/list), so every interaction with that refresh the model will respect the matter_id of the route

  model: function(params) {
    params['matter_id'] = this.get('currentMatter.id');
    return this._super(params);
  },
